### PR TITLE
Add cache control header to ImageResponse in days-in-year route

### DIFF
--- a/app/types/days-in-year/file/route.tsx
+++ b/app/types/days-in-year/file/route.tsx
@@ -195,6 +195,11 @@ export async function GET(request: NextRequest) {
 
 	// ── Response ──────────────────────────────────────────────────────────────────
 
+	const now = new Date();
+	const midnight = new Date(now);
+	midnight.setUTCHours(24, 0, 0, 0);
+	const secondsUntilMidnight = Math.floor((midnight.getTime() - now.getTime()) / 1000);
+
 	return new ImageResponse(
 		(
 			<div
@@ -218,6 +223,9 @@ export async function GET(request: NextRequest) {
 		{
 			width: model.width,
 			height: model.height,
+			headers: {
+				"cache-control": `public, max-age=0, s-maxage=${secondsUntilMidnight}`,
+			},
 		},
 	);
 }


### PR DESCRIPTION
- Introduced calculation for seconds until midnight to dynamically set cache control header.
- Enhanced ImageResponse configuration to include cache control for improved performance.

this is trying to fix #9 